### PR TITLE
fix nextra error

### DIFF
--- a/pages/index.zh.md
+++ b/pages/index.zh.md
@@ -12,7 +12,7 @@ YoMo 是一个为边缘计算领域打造的低时延流式数据处理框架，
 ## 快速入门 👨‍💻
 
 > **注意：** YoMo 的运行环境要求 Go 版本为 1.15 或以上，运行 `go version` 获取当前环境的版本，如果未安装 Go 或者不符合 Go 版本要求时，请安装或者升级 Go 版本。
-安装 Go 环境之后，国内用户可参考 <https://goproxy.cn/> 设置 `GOPROXY`，以便下载 YoMo 项目依赖。
+安装 Go 环境之后，国内用户可参考 &lt;https://goproxy.cn/&gt; 设置 `GOPROXY`，以便下载 YoMo 项目依赖。
 
 ### 1. 安装 CLI
 


### PR DESCRIPTION
因为这里的 markdown 其实是 [mdx](https://mdxjs.com/)，所以如果带有 `<` `>` 的话都会当作是 jsx 来理解的。